### PR TITLE
[benchmark]

### DIFF
--- a/benchmarks/perf-flights-old-code.js
+++ b/benchmarks/perf-flights-old-code.js
@@ -12,11 +12,11 @@ const instance = autocannon({
   body: postData,
   headers: {
     'Content-Type': 'application/x-www-form-urlencoded',
-    'Cookie': 'sessionid=0bdaf762-2eed-4adc-ad75-674565f74bb5; loggedinuser=uid0%40email.com'
+    'Cookie': 'sessionid=b0c277a0-f097-4074-b963-ef5819e5f8a3; loggedinuser=uid0%40email.com'
   },
   connections: 10,
   pipelining: 1,
-  duration: 10
+  duration: 30
 }, console.log)
 
 process.once('SIGINT', () => {

--- a/benchmarks/perf-flights.js
+++ b/benchmarks/perf-flights.js
@@ -6,17 +6,17 @@ const url = 'http://localhost:9080/rest/api/flights'
 const postData = 'fromAirport=BOM&toAirport=AMS&fromDate=Thu%20Jun%2021%202018%2000%3A00%3A00%20GMT-0500%20(Central%20Daylight%20Time)&returnDate=Thu%20Jun%2021%202018%2000%3A00%3A00%20GMT-0500%20(Central%20Daylight%20Time)&oneWay=false'
 
 const instance = autocannon({
-    title: 'acmeair-flights',
-    url,
-    method: 'POST',
-    body: postData,
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
-    },
-    connections: 10,
-    pipelining: 1,
-    duration: 30
-  }, console.log)
+  title: 'acmeair-flights',
+  url,
+  method: 'POST',
+  body: postData,
+  headers: {
+    'Content-Type': 'application/x-www-form-urlencoded'
+  },
+  connections: 10,
+  pipelining: 1,
+  duration: 30
+}, console.log)
 
 process.once('SIGINT', () => {
   instance.stop()

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -98,6 +98,16 @@ const createCollection = async (options, context) => {
   return results
 }
 
+const createIndices = async (options, context) => {
+  // only intended for mongo, related to benchmark queries
+  if (options.dbType !== 'mongo') { return 'done' }
+
+  const {dbClient, dbType} = options
+  const dbService = determineDbService(dbType)
+  const results = dbService.createIndices(dbClient, context)
+  return results
+}
+
 module.exports = {
   count,
   deleteOne,
@@ -107,5 +117,6 @@ module.exports = {
   insertMany,
   insertOne,
   update,
-  names: dbNames
+  names: dbNames,
+  createIndices
 }

--- a/src/db/mongo.js
+++ b/src/db/mongo.js
@@ -45,6 +45,20 @@ const update = async (dbClient, collectionName, query, doc) => {
   return {success, data: doc}
 }
 
+const createIndex = async (dbClient, context) => {
+  const collection = dbClient.db.collection(context.collectionName)
+  await collection.createIndex(context.fields, context.options)
+  return 'done'
+}
+
+const createIndices = async (dbClient, context) => {
+  context.forEach(async (item) => {
+    await createIndex(dbClient, item)
+  })
+
+  return 'done'
+}
+
 module.exports = {
   count,
   deleteOne,
@@ -52,5 +66,6 @@ module.exports = {
   find,
   insertOne,
   insertMany,
-  update
+  update,
+  createIndices
 }

--- a/src/loader/index.js
+++ b/src/loader/index.js
@@ -17,7 +17,8 @@ const {
   createCollection,
   find,
   insertMany,
-  names
+  names,
+  createIndices
 } = require('../db')
 
 const loadCustomers = async (options, count) => {
@@ -111,11 +112,43 @@ const createEmptyCollection = async (options, collectionName) => {
   return 'done'
 }
 
+// https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/#db.collection.createIndex
+const createIndicesForBenchmark = async (options) => {
+  const indicies = [
+    {
+      collectionName: names.flight,
+      fields: {
+        flightSegmentId: 1,
+        scheduledDepartureTime: 2
+      },
+      options: {
+        name: 'flight_segment_departureTime',
+        background: true
+      }
+    },
+    {
+      collectionName: names.flightSegment,
+      fields: {
+        originPort: 1,
+        destPort: 2
+      },
+      options: {
+        name: 'flightSegment_origin_dest',
+        background: true
+      }
+    }
+  ]
+
+  await createIndices(options, indicies)
+  return 'done'
+}
+
 const load = async (options, count) => {
   await loadCustomers(options, count)
   await loadAirportCodes(options)
   await loadFlightSegments(options)
   await loadFlights(options)
+  await createIndicesForBenchmark(options)
   await createEmptyCollection(options, names.booking)
   await createEmptyCollection(options, names.session)
 


### PR DESCRIPTION
this brings our query in line with the previous version's flight query. we now query one flight segment, which results in one flight.

### original acmeair
```
Running 30s test @ http://localhost:9080/rest/api/flights/queryflights
10 connections

Stat         Avg    Stdev   Max    
Latency (ms) 16.18  7.95    212.33 
Req/Sec      599.37 46.6    677    
Bytes/Sec    472 kB 38.1 kB 533 kB 

18k requests in 30s, 14.2 MB read
null { title: 'acmeair-flights-old-code',
  url: 'http://localhost:9080/rest/api/flights/queryflights',
  socketPath: undefined,
  requests: 
   { average: 599.37,
     mean: 599.37,
     stddev: 46.6,
     min: 488,
     max: 677,
     total: 17981,
     sent: 17991 },
  latency: 
   { average: 16.18,
     mean: 16.18,
     stddev: 7.95,
     min: 3,
     max: 212.334212,
     p50: 15,
     p75: 19,
     p90: 24,
     p99: 38,
     p999: 61,
     p9999: 207,
     p99999: 212 },
  throughput: 
   { average: 471586.14,
     mean: 471586.14,
     stddev: 38054.37,
     min: 384056,
     max: 532799,
     total: 14151047 },
  errors: 0,
  timeouts: 0,
  duration: 30,
  start: 2018-06-27T11:40:16.140Z,
  finish: 2018-06-27T11:40:46.166Z,
  connections: 10,
  pipelining: 1,
  non2xx: 0,
  '1xx': 0,
  '2xx': 17981,
  '3xx': 0,
  '4xx': 0,
  '5xx': 0 }
```

### new version results
```
Running 30s test @ http://localhost:9080/rest/api/flights
10 connections

Stat         Avg    Stdev   Max     
Latency (ms) 14.7   23.48   1012.77 
Req/Sec      657.67 124.01  747     
Bytes/Sec    104 kB 19.7 kB 118 kB  

20k requests in 30s, 3.12 MB read
null { title: 'acmeair-flights',
  url: 'http://localhost:9080/rest/api/flights',
  socketPath: undefined,
  requests: 
   { average: 657.67,
     mean: 657.67,
     stddev: 124.01,
     min: 21,
     max: 747,
     total: 19730,
     sent: 19740 },
  latency: 
   { average: 14.7,
     mean: 14.7,
     stddev: 23.48,
     min: 2,
     max: 1012.772756,
     p50: 13,
     p75: 18,
     p90: 23,
     p99: 39,
     p999: 61,
     p9999: 1009,
     p99999: 1012 },
  throughput: 
   { average: 103805.87,
     mean: 103805.87,
     stddev: 19693.59,
     min: 3318,
     max: 118026,
     total: 3117340 },
  errors: 0,
  timeouts: 0,
  duration: 30,
  start: 2018-06-27T13:26:27.561Z,
  finish: 2018-06-27T13:26:57.592Z,
  connections: 10,
  pipelining: 1,
  non2xx: 0,
  '1xx': 0,
  '2xx': 19730,
  '3xx': 0,
  '4xx': 0,
  '5xx': 0 }
```

related: #3 
